### PR TITLE
docs: add Local AI Chat feature proposal and implementation plan

### DIFF
--- a/docs/features/local-ai-chat/README.md
+++ b/docs/features/local-ai-chat/README.md
@@ -6,12 +6,13 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 시장의 AI 코딩 도구들(Cursor, Windsurf 등)은 자체 API 키 기반으로 동작하여 사용자에게 추가 비용을 부과하거나, 특정 모델/프롬프트 포맷에 종속된다. 반면, **Claude Code**, **Gemini CLI**, **Codex CLI** 같은 로컬 AI CLI 도구들은 사용자의 기존 구독(Claude Pro, Gemini Advanced, ChatGPT Plus 등)을 그대로 활용하며, **파일 시스템을 직접 읽고 쓰는 에이전트** 방식으로 동작한다.
 
-이 기획은 Magam 내에 채팅 인터페이스를 도입하되, 백엔드 API 서버를 두지 않고 **사용자의 로컬 머신에 설치된 AI CLI를 직접 호출**하는 방식을 제안한다. 이를 통해:
+이 기획은 Magam 내에 채팅 인터페이스를 도입하되, 백엔드 API 서버를 두지 않고 **사용자의 로컬 머신에 설치된 AI CLI를 공식 SDK를 통해 호출**하는 방식을 제안한다. Claude Code와 Codex CLI는 각각 공식 TypeScript SDK(`@anthropic-ai/claude-agent-sdk`, `@openai/codex-sdk`)를 제공하며, 이 SDK들은 내부적으로 CLI를 subprocess로 spawn하고 JSONL로 통신하는 구조이다. 이를 통해:
 
 1. **사용자 구독 활용**: 추가 API 비용 없이 사용자의 기존 AI 구독을 그대로 사용
 2. **파일 I/O 기반 처리**: 텍스트 출력 포맷을 강제하지 않고, AI가 직접 파일을 읽고 수정
 3. **실시간 반영**: 기존 파일 감시(chokidar) + WebSocket 파이프라인을 통해 AI의 파일 변경이 즉시 캔버스에 반영
 4. **모델 자유 선택**: 사용자가 원하는 AI 도구를 자유롭게 선택 가능
+5. **공식 SDK 활용**: 출력 파싱, 세션 관리, 프로세스 라이프사이클을 SDK가 캡슐화하여 유지보수 부담 최소화
 
 ---
 
@@ -59,7 +60,35 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 4. 목표와 비목표
+## 4. 선행 사례 (Prior Art)
+
+이 "로컬 AI CLI를 프록시하는" 접근법은 이미 활발한 오픈소스 생태계가 검증하고 있다.
+
+### 4.1 CLIProxyAPI
+
+[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)는 Go로 작성된 프로젝트로, Claude Code / Gemini CLI / Codex CLI 등을 자식 프로세스로 spawn하고 OpenAI 호환 API로 노출한다. 모델 이름 prefix로 라우팅하며 (`claude-*` → Claude Code, `gemini-*` → Gemini CLI), 사용자의 기존 OAuth 구독을 그대로 활용한다. 멀티 계정 로드밸런싱을 지원하며, macOS 앱(VibeProxy), VSCode 확장, Windows 데스크톱 앱 등 풍부한 파생 생태계가 형성되어 있다.
+
+### 4.2 공식 SDK
+
+| CLI | 공식 SDK | 내부 동작 |
+|-----|---------|----------|
+| **Claude Code** | `@anthropic-ai/claude-agent-sdk` (TypeScript/Python) | CLI를 subprocess로 spawn, stdin/stdout으로 **JSONL 양방향 통신** |
+| **Codex CLI** | `@openai/codex-sdk` (TypeScript) | CLI를 subprocess로 spawn, stdin/stdout으로 **JSONL 스트리밍** |
+| **Gemini CLI** | 공식 SDK 없음 (요청 중) | 직접 `child_process.spawn` 필요 |
+
+Claude Agent SDK와 Codex SDK는 모두 **우리가 설계하려는 것과 동일한 패턴(subprocess spawn + JSONL 파싱)을 이미 캡슐화**하고 있다.
+
+### 4.3 Magam의 차별점
+
+CLIProxyAPI 등 기존 프로젝트는 **범용 API 프록시**이다. Magam의 Local AI Chat은:
+
+- **도메인 특화**: 시스템 프롬프트에 `@magam/core` 컴포넌트 API를 자동 주입하여 정확한 다이어그램 TSX 생성 유도
+- **캔버스 실시간 연동**: 파일 변경 → chokidar → WebSocket → 캔버스 자동 업데이트라는 기존 파이프라인과 자연스럽게 통합
+- **시각적 피드백 루프**: AI가 파일을 수정하면 다이어그램이 눈앞에서 변하는 경험을 제공
+
+---
+
+## 5. 목표와 비목표
 
 ### 목표 (Goals)
 
@@ -80,24 +109,36 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 5. 지원 AI CLI 도구
+## 6. 지원 AI CLI 도구
 
-### 5.1 1차 지원 대상
+### 6.1 1차 지원 대상
 
-| CLI 도구 | 실행 명령어 | 주요 특징 | 필요 구독 |
-|----------|------------|----------|----------|
-| **Claude Code** | `claude` | 파일 읽기/쓰기, 터미널 명령 실행, 프로젝트 이해 | Claude Pro/Max/Team |
-| **Gemini CLI** | `gemini` | Google AI 기반, 파일 편집, 코드 생성 | Gemini Advanced 또는 API 키 |
-| **Codex CLI** | `codex` | OpenAI 기반, 코드 생성/수정, 파일 조작 | ChatGPT Plus/Pro 또는 API 키 |
+| CLI 도구 | 실행 명령어 | 공식 SDK | 비대화형 모드 | 필요 구독 |
+|----------|------------|---------|-------------|----------|
+| **Claude Code** | `claude` | `@anthropic-ai/claude-agent-sdk` | `claude -p --output-format stream-json` | Claude Pro/Max/Team |
+| **Gemini CLI** | `gemini` | 없음 (직접 spawn) | `gemini "prompt"` (positional arg) | Gemini Advanced 또는 API 키 |
+| **Codex CLI** | `codex` | `@openai/codex-sdk` | `codex exec --json "prompt"` | ChatGPT Plus/Pro 또는 API 키 |
 
-### 5.2 CLI 감지 전략
+### 6.2 통합 전략 (SDK 우선)
 
-1. `which` / `where` 명령으로 실행 파일 존재 여부 확인
-2. `--version` 또는 `--help` 실행으로 설치 상태 검증
-3. 감지 결과를 캐시하여 반복 확인 방지
-4. 미설치 도구는 UI에서 비활성 표시 + 설치 안내 링크 제공
+```
+CLIAdapter (공통 인터페이스)
+  ├── ClaudeAdapter  → @anthropic-ai/claude-agent-sdk (SDK가 subprocess + JSONL 관리)
+  ├── CodexAdapter   → @openai/codex-sdk             (SDK가 subprocess + JSONL 관리)
+  └── GeminiAdapter  → child_process.spawn()          (SDK 미제공, 직접 관리)
+```
 
-### 5.3 확장 가능성
+Claude Code와 Codex CLI는 **공식 SDK를 통해 호출**한다. SDK가 subprocess spawn, JSONL 파싱, 세션 관리, 에러 핸들링을 캡슐화하므로 직접 구현할 필요가 없다. Gemini CLI만 공식 SDK가 없어 `child_process.spawn`으로 직접 관리한다.
+
+### 6.3 CLI 감지 전략
+
+1. SDK 패키지 import 가능 여부 확인 (Claude, Codex)
+2. `which` / `where` 명령으로 CLI 실행 파일 존재 여부 확인 (Gemini, 폴백)
+3. `--version` 실행으로 설치 상태 검증
+4. 감지 결과를 캐시하여 반복 확인 방지
+5. 미설치 도구는 UI에서 비활성 표시 + 설치 안내 링크 제공
+
+### 6.4 확장 가능성
 
 플러그인/어댑터 패턴으로 설계하여 향후 추가 CLI 도구 지원이 용이하도록 한다:
 - Aider
@@ -107,14 +148,14 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 6. 사용자 시나리오
+## 7. 사용자 시나리오
 
 ### 시나리오 A: 새 다이어그램 생성
 
 1. 사용자가 빈 파일(`architecture.tsx`)을 열고 채팅 패널을 연다.
 2. AI 도구로 "Claude Code"를 선택한다.
 3. 채팅에 "마이크로서비스 아키텍처 다이어그램을 그려줘. API Gateway, Auth Service, User Service, Order Service를 포함해줘"라고 입력한다.
-4. Magam이 `claude --print` 명령에 프로젝트 컨텍스트와 함께 프롬프트를 전달한다.
+4. Magam이 Claude Agent SDK의 `query()` API에 프로젝트 컨텍스트와 함께 프롬프트를 전달한다.
 5. Claude Code가 `architecture.tsx` 파일을 직접 수정한다.
 6. 파일 변경이 감지되어 캔버스에 마이크로서비스 다이어그램이 자동으로 나타난다.
 7. 채팅에 AI의 응답(작업 내용 설명)이 스트리밍된다.
@@ -150,14 +191,14 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 7. 기능 요구사항
+## 8. 기능 요구사항
 
 | ID | 요구사항 | 수용 기준 (Acceptance Criteria) |
 |---|---|---|
 | FR-1 | 채팅 패널 UI | 사이드바 또는 하단 패널에서 채팅 인터페이스가 열리고, 메시지 입력/표시가 동작한다. |
 | FR-2 | AI CLI 자동 감지 | 앱 시작 시 `claude`, `gemini`, `codex` 설치 여부를 확인하고 UI에 표시한다. |
 | FR-3 | AI 도구 선택 | 감지된 CLI 중 하나를 선택할 수 있으며, 기본값은 첫 번째 감지된 도구이다. |
-| FR-4 | 메시지 전송 및 CLI 실행 | 사용자 메시지 전송 시 선택된 CLI가 자식 프로세스로 실행되고 프롬프트가 전달된다. |
+| FR-4 | 메시지 전송 및 CLI 실행 | 사용자 메시지 전송 시 선택된 CLI가 공식 SDK(또는 직접 spawn)를 통해 실행되고 프롬프트가 전달된다. |
 | FR-5 | 실시간 응답 스트리밍 | AI CLI의 stdout을 실시간으로 읽어 채팅 UI에 점진적으로 표시한다. |
 | FR-6 | 파일 변경 자동 반영 | AI가 수정한 파일이 기존 파일 감시 파이프라인을 통해 캔버스에 자동 반영된다. |
 | FR-7 | 시스템 프롬프트 자동 구성 | 현재 파일, Magam 컴포넌트 API, 프로젝트 구조를 시스템 프롬프트에 자동 포함한다. |
@@ -169,7 +210,7 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 8. 비기능 요구사항
+## 9. 비기능 요구사항
 
 | ID | 항목 | 기준 |
 |---|---|---|
@@ -183,7 +224,7 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 9. UX 제안
+## 10. UX 제안
 
 ### 9.1 채팅 패널 레이아웃
 
@@ -247,9 +288,9 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 
 ---
 
-## 10. 기술 설계 개요
+## 11. 기술 설계 개요
 
-### 10.1 아키텍처
+### 11.1 아키텍처 (SDK 기반)
 
 ```
 ┌─ Next.js Frontend (Port 3000) ─────────────────────────┐
@@ -270,26 +311,25 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 └──────────────────────┬───────────────────────────────────┘
                        │ API Route / WebSocket
                        ▼
-┌─ CLI Server Layer (Port 3002 or 3001) ──────────────────┐
+┌─ CLI Server Layer (Port 3002) ─────────────────────────┐
 │                                                          │
 │  ChatHandler                                             │
 │    ├─ CLIDetector (설치 감지)                              │
-│    ├─ CLIAdapter (claude | gemini | codex)                │
-│    │    ├─ 프로세스 spawn                                  │
-│    │    ├─ stdin에 프롬프트 전달                            │
-│    │    ├─ stdout/stderr 스트리밍                          │
-│    │    └─ 프로세스 라이프사이클 관리                        │
+│    ├─ CLIAdapter (공통 인터페이스)                          │
+│    │    ├─ ClaudeAdapter  → claude-agent-sdk (JSONL)     │
+│    │    ├─ CodexAdapter   → codex-sdk (JSONL)            │
+│    │    └─ GeminiAdapter  → child_process.spawn (raw)    │
 │    ├─ PromptBuilder (시스템 프롬프트 구성)                   │
 │    └─ SessionManager (세션/히스토리)                        │
 │                                                          │
 └──────────────────────┬───────────────────────────────────┘
-                       │ child_process.spawn()
+                       │ SDK가 내부적으로 subprocess 관리
                        ▼
-┌─ Local AI CLI ──────────────────────────────────────────┐
+┌─ Local AI CLI (SDK가 관리하는 subprocess) ────────────────┐
 │  claude / gemini / codex                                 │
 │    ├─ 프로젝트 파일 읽기                                   │
 │    ├─ 파일 수정/생성                                      │
-│    └─ stdout으로 진행 상황 출력                             │
+│    └─ JSONL 또는 stdout으로 진행 상황 출력                  │
 └──────────────────────┬───────────────────────────────────┘
                        │ 파일 시스템 변경
                        ▼
@@ -299,18 +339,23 @@ Magam는 사용자가 TSX 코드로 다이어그램을 작성하면 캔버스에
 └─────────────────────────────────────────────────────────┘
 ```
 
-### 10.2 CLI 어댑터 인터페이스
+### 11.2 CLI 어댑터 인터페이스 (SDK 우선 설계)
 
 ```ts
+// 공통 어댑터 인터페이스
 interface CLIAdapter {
-  name: string;                    // 'claude' | 'gemini' | 'codex'
+  id: ProviderId;                  // 'claude' | 'gemini' | 'codex'
   displayName: string;             // 'Claude Code' | 'Gemini CLI' | 'Codex CLI'
-  command: string;                 // 실행 파일 경로
-  isInstalled(): Promise<boolean>;
-  getVersion(): Promise<string | null>;
-  buildArgs(prompt: string, options: CLIRunOptions): string[];
-  spawn(args: string[], cwd: string): ChildProcess;
-  parseOutputStream(stream: Readable): AsyncIterable<ChatChunk>;
+  installUrl: string;
+
+  // 감지
+  detect(): Promise<ProviderInfo>;
+
+  // 실행 — SDK 또는 직접 spawn 내부 구현에 따라 다름
+  run(prompt: string, options: CLIRunOptions): AsyncIterable<ChatChunk>;
+
+  // 중단
+  abort(): void;
 }
 
 interface CLIRunOptions {
@@ -318,7 +363,6 @@ interface CLIRunOptions {
   workingDirectory: string;
   currentFile?: string;
   timeout?: number;               // 기본 300초
-  allowedTools?: string[];        // CLI별 허용 도구 제한
 }
 
 interface ChatChunk {
@@ -328,17 +372,48 @@ interface ChatChunk {
 }
 ```
 
-### 10.3 CLI별 실행 전략
+### 11.3 CLI별 통합 전략
 
-| CLI | 실행 방식 | 프롬프트 전달 | 출력 파싱 |
-|-----|----------|-------------|----------|
-| Claude Code | `claude --print -p "prompt"` 또는 `claude --json` | CLI 인자 또는 stdin pipe | stdout 텍스트 스트림 |
-| Gemini CLI | `gemini -p "prompt"` | CLI 인자 | stdout 텍스트 스트림 |
-| Codex CLI | `codex "prompt"` | CLI 인자 | stdout 텍스트 스트림 |
+| CLI | 통합 방식 | 패키지 | 스트리밍 | 세션 관리 |
+|-----|----------|--------|---------|----------|
+| **Claude Code** | **Claude Agent SDK** | `@anthropic-ai/claude-agent-sdk` | `query()` → async iterator (JSONL) | SDK 내장 (session fork/resume) |
+| **Codex CLI** | **Codex SDK** | `@openai/codex-sdk` | `runStreamed()` → async generator (JSONL events) | SDK 내장 (`Thread` + `resumeThread()`) |
+| **Gemini CLI** | **직접 spawn** | `child_process` | stdout stream → NDJSON 또는 raw text 파싱 | 자체 구현 (세션 ID + `--resume` flag) |
 
-> 각 CLI의 정확한 인자 형식은 구현 시점의 최신 CLI 버전에 맞춰 조정한다.
+**Claude Agent SDK 사용 예시:**
+```ts
+import { query } from '@anthropic-ai/claude-agent-sdk';
 
-### 10.4 시스템 프롬프트 자동 구성
+const messages = query({
+  prompt: userMessage,
+  options: {
+    systemPrompt: magamContext,
+    cwd: workingDirectory,
+    allowedTools: ['Read', 'Write', 'Edit'],
+  }
+});
+
+for await (const message of messages) {
+  // JSONL 메시지 → ChatChunk로 변환하여 SSE 전송
+}
+```
+
+**Codex SDK 사용 예시:**
+```ts
+import { Codex } from '@openai/codex-sdk';
+
+const codex = new Codex();
+const thread = codex.startThread();
+const stream = thread.runStreamed(userMessage);
+
+for await (const event of stream) {
+  // JSONL 이벤트 → ChatChunk로 변환하여 SSE 전송
+}
+```
+
+> Gemini CLI만 SDK가 없으므로 `child_process.spawn`으로 직접 관리한다. Gemini CLI의 공식 SDK가 출시되면 어댑터를 SDK 기반으로 교체한다.
+
+### 11.4 시스템 프롬프트 자동 구성
 
 AI CLI 호출 시 다음 컨텍스트를 자동으로 포함한다:
 
@@ -363,7 +438,7 @@ AI CLI 호출 시 다음 컨텍스트를 자동으로 포함한다:
    - Tailwind 클래스 사용 가능
 ```
 
-### 10.5 변경 지점 요약
+### 11.5 변경 지점 요약
 
 | 레이어 | 파일/모듈 | 변경 내용 |
 |--------|----------|----------|
@@ -371,13 +446,13 @@ AI CLI 호출 시 다음 컨텍스트를 자동으로 포함한다:
 | Frontend | `app/components/chat/` | ChatPanel, MessageList, ChatInput, AISelector 컴포넌트 신규 |
 | Frontend | `app/components/ui/Header.tsx` | 채팅 토글 버튼 추가 |
 | Frontend | `app/app/api/chat/` | 채팅 API 라우트 (CLI 실행 프록시) |
-| Backend | `libs/cli/src/chat/` | CLIDetector, CLIAdapter, PromptBuilder, SessionManager 신규 |
+| Backend | `libs/cli/src/chat/` | CLIDetector, CLIAdapter(SDK 래퍼), PromptBuilder, SessionManager 신규 |
 | Backend | `libs/cli/src/server/http.ts` | `/chat/send`, `/chat/providers`, `/chat/stop` 엔드포인트 추가 |
 | Shared | `libs/shared/src/` | 채팅 관련 공용 타입 정의 |
 
 ---
 
-## 11. 단계별 구현 계획
+## 12. 단계별 구현 계획
 
 ### Phase 1: CLI 감지 및 어댑터 기반 구축
 
@@ -436,7 +511,7 @@ AI CLI 호출 시 다음 컨텍스트를 자동으로 포함한다:
 
 ---
 
-## 12. 성공 지표
+## 13. 성공 지표
 
 1. **채팅 사용률**: 활성 사용자 중 채팅 기능 사용 비율 50% 이상
 2. **다이어그램 생성 효율**: AI 채팅을 통한 다이어그램 생성/수정 성공률 80% 이상
@@ -446,26 +521,27 @@ AI CLI 호출 시 다음 컨텍스트를 자동으로 포함한다:
 
 ---
 
-## 13. 리스크 및 대응
+## 14. 리스크 및 대응
 
-| 리스크 | 영향 | 대응 |
-|--------|------|------|
-| CLI 도구 인터페이스 변경 | 어댑터 호환성 깨짐 | 어댑터 패턴으로 격리, 버전별 분기, CI에서 호환성 테스트 |
-| CLI 프로세스 무한 대기/행 | 리소스 누수, UX 저하 | 타임아웃(기본 300초), 강제 종료, 프로세스 모니터링 |
-| 사용자 CLI 미설치 | 기능 사용 불가 | 명확한 안내 UI, 설치 가이드, 대체 수단 제안 |
-| AI의 잘못된 파일 수정 | 다이어그램 깨짐 | 수정 전 파일 백업, undo 기능, 변경 diff 표시 |
-| 보안: CLI 인자 인젝션 | 임의 명령 실행 | 인자 이스케이프, allowlist 기반 검증, 사용자 확인 |
-| stdout 파싱 불일치 | 응답 표시 오류 | CLI별 파서 분리, 폴백 raw 텍스트 표시 |
-| 대용량 프로젝트 컨텍스트 | CLI 토큰 한도 초과 | 컨텍스트 크기 제한, 관련 파일만 선별, 요약 전략 |
+| 리스크 | 영향 | 심각도 | 대응 |
+|--------|------|--------|------|
+| CLI 도구 인터페이스 변경 | 어댑터 호환성 깨짐 | **낮음** (SDK가 흡수) | SDK 버전 업그레이드로 대응, Gemini만 직접 분기 필요 |
+| CLI 프로세스 무한 대기/행 | 리소스 누수, UX 저하 | **낮음** (SDK가 관리) | SDK timeout 옵션 활용, Gemini는 자체 타임아웃 구현 |
+| 사용자 CLI 미설치 | 기능 사용 불가 | 중간 | 명확한 안내 UI, 설치 가이드, 대체 수단 제안 |
+| AI의 잘못된 파일 수정 | 다이어그램 깨짐 | 중간 | 수정 전 파일 백업, undo 기능, 변경 diff 표시 |
+| 보안: CLI 인자 인젝션 | 임의 명령 실행 | **낮음** (SDK가 격리) | SDK의 `allowedTools` 옵션으로 도구 제한, Gemini는 `shell: false` 강제 |
+| Gemini CLI stdout 파싱 불안정 | 응답 표시 오류 | 중간 | raw 텍스트 폴백 표시, NDJSON 모드 우선 사용, 에러 격리 |
+| 대용량 프로젝트 컨텍스트 | CLI 토큰 한도 초과 | 중간 | 컨텍스트 크기 제한, 관련 파일만 선별, 요약 전략 |
+| SDK 패키지 크기 | 번들 사이즈 증가 | 낮음 | 서버 사이드에서만 사용 (클라이언트 번들에 미포함) |
 
 ---
 
-## 14. 오픈 질문
+## 15. 오픈 질문
 
-1. **세션 영속성**: 채팅 히스토리를 파일 시스템에 저장할지, 메모리에서만 유지할지?
+1. **세션 영속성**: 채팅 히스토리를 파일 시스템에 저장할지, 메모리에서만 유지할지? (SDK의 세션 resume 기능 활용 가능)
 2. **멀티 파일 편집**: AI가 여러 파일을 동시에 수정할 때의 UX는? (변경 파일 목록 표시? 개별 확인?)
-3. **권한 모델**: AI CLI 실행 시 사용자에게 매번 확인을 받을지, 세션 단위로 허용할지?
+3. **권한 모델**: AI CLI 실행 시 사용자에게 매번 확인을 받을지, 세션 단위로 허용할지? (SDK의 `allowedTools` 활용)
 4. **컨텍스트 범위**: 시스템 프롬프트에 현재 파일만 포함할지, 전체 프로젝트 파일을 포함할지?
 5. **CLI 동시 실행**: 이전 요청이 처리 중일 때 새 요청을 큐잉할지, 이전 요청을 중단할지?
-6. **오프라인 모드**: CLI 도구가 네트워크 없이 동작하는 경우에 대한 별도 지원이 필요한지?
-7. **채팅 패널 위치**: 오른쪽 사이드바 고정 vs 하단 패널 vs 사용자 선택 가능?
+6. **채팅 패널 위치**: 오른쪽 사이드바 고정 vs 하단 패널 vs 사용자 선택 가능?
+7. **SDK 버전 고정 전략**: SDK 버전을 pinning할지, range로 허용할지?


### PR DESCRIPTION
Introduce a new feature concept for integrating local AI CLI tools
(Claude Code, Gemini CLI, Codex CLI) into Magam's chat interface.
This "Bring Your Own AI" approach lets users leverage their existing
subscriptions while AI tools directly read/write project files,
with changes automatically reflected on the canvas.

https://claude.ai/code/session_013ohqXLno1gGWxYbrxaY1ze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design documentation for the Local AI Chat feature, outlining architecture, component responsibilities, data models, and a detailed phased implementation roadmap for integrating local AI CLI tools with real-time file editing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->