### PR TITLE
fix(build): resolve app+cli build blockers

### DIFF
--- a/app/app/api/assets/file/route.ts
+++ b/app/app/api/assets/file/route.ts
@@ -75,12 +75,13 @@ export async function GET(request: Request) {
 
     const buffer = await readFile(absPath);
     const mimeType = getMimeType(extension);
+    const body = new Uint8Array(buffer);
 
-    return new Response(buffer, {
+    return new Response(body, {
       status: 200,
       headers: {
         'Content-Type': mimeType,
-        'Content-Length': buffer.length.toString(),
+        'Content-Length': body.byteLength.toString(),
         'Cache-Control': 'public, max-age=31536000, immutable',
         'X-Content-Hash': createHash('sha256').update(buffer).digest('hex'),
       },

--- a/app/utils/search.ts
+++ b/app/utils/search.ts
@@ -94,7 +94,7 @@ export const getMatchKind = (text: string, query: string): MatchKind | undefined
   return undefined;
 };
 
-export const buildSearchIndex = (nodes: Node[], currentFile: string | null): SearchIndexItem[] => {
+export const buildSearchIndex = (nodes: Node[], currentFile: string | null): SearchIndexElementItem[] => {
   const nodeItems: SearchIndexElementItem[] = nodes.map((node) => {
     const data = (node as Node<Record<string, unknown>>).data || {};
     const filePath = toText((data as { filePath?: string }).filePath) || currentFile || 'untitled';

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,8 @@
       "devDependencies": {
         "@eslint/js": "^9.8.0",
         "@playwright/test": "^1.58.2",
+        "@types/babel__generator": "^7.27.0",
+        "@types/babel__traverse": "^7.28.0",
         "@types/bun": "^1.3.8",
         "@types/node": "20.19.9",
         "@types/react": "^18.3.1",

--- a/libs/cli/tsup.config.ts
+++ b/libs/cli/tsup.config.ts
@@ -11,5 +11,8 @@ export default defineConfig({
     'react',
     'esbuild',
     '@modelcontextprotocol/sdk',
+    'drizzle-orm',
+    'drizzle-orm/*',
+    'bun:sqlite',
   ],
 });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@eslint/js": "^9.8.0",
     "@playwright/test": "^1.58.2",
     "@types/bun": "^1.3.8",
+    "@types/babel__generator": "^7.27.0",
+    "@types/babel__traverse": "^7.28.0",
     "@types/node": "20.19.9",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary
Fixes build blockers found after chat session management merge.

## Changes
- fix Response body typing in  by returning 
- remove stale  directives in 
- narrow search index return type in 
- mark Bun/Drizzle runtime modules as external in 
- add missing Babel type packages (, )

## Validation
- @magam/shared build: CLI Building entry: src/index.ts
@magam/shared build: CLI Using tsconfig: tsconfig.json
@magam/shared build: CLI tsup v8.5.1
@magam/shared build: CLI Target: es2015
@magam/shared build: CJS Build start
@magam/shared build: ESM Build start
@magam/shared build: CJS You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/shared build: ESM You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/core build: CLI Building entry: src/index.ts
@magam/core build: CLI Using tsconfig: tsconfig.lib.json
@magam/core build: CLI tsup v8.5.1
@magam/core build: CLI Using tsup config: /Users/danghamo/Documents/gituhb/magam/libs/core/tsup.config.ts
@magam/core build: CLI Target: es2015
@magam/core build: CLI Cleaning output folder
@magam/core build: CJS Build start
@magam/core build: ESM Build start
@magam/core build: CJS You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/core build: ESM You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/shared build: ESM dist/index.mjs 4.63 KB
@magam/shared build: ESM ⚡️ Build success in 16ms
@magam/shared build: CJS dist/index.js 130.83 KB
@magam/shared build: CJS ⚡️ Build success in 27ms
@magam/core build: ESM dist/index.mjs 21.08 KB
@magam/core build: ESM ⚡️ Build success in 21ms
@magam/core build: CJS dist/index.js 23.70 KB
@magam/core build: CJS ⚡️ Build success in 21ms
magam-app build:    ▲ Next.js 15.5.12
magam-app build: 
@magam/shared build: DTS Build start
@magam/core build: DTS Build start
magam-app build:    Creating an optimized production build ...
@magam/shared build: DTS ⚡️ Build success in 692ms
@magam/shared build: DTS dist/index.d.ts  5.37 KB
@magam/shared build: DTS dist/index.d.mts 5.37 KB
@magam/shared build: Exited with code 0
@magam/core build: DTS ⚡️ Build success in 724ms
@magam/core build: DTS dist/index.d.ts  10.69 KB
@magam/core build: DTS dist/index.d.mts 10.69 KB
@magam/core build: Exited with code 0
@magam/runtime build: CLI Building entry: src/index.ts
@magam/cli build: CLI Building entry: src/bin.ts, src/index.ts
@magam/runtime build: CLI Using tsconfig: tsconfig.json
@magam/runtime build: CLI tsup v8.5.1
@magam/cli build: CLI Using tsconfig: tsconfig.json
@magam/runtime build: CLI Using tsup config: /Users/danghamo/Documents/gituhb/magam/libs/runtime/tsup.config.ts
@magam/cli build: CLI tsup v8.5.1
@magam/cli build: CLI Using tsup config: /Users/danghamo/Documents/gituhb/magam/libs/cli/tsup.config.ts
@magam/runtime build: CLI Target: es2015
@magam/cli build: CLI Target: es2015
@magam/runtime build: CLI Cleaning output folder
@magam/cli build: CLI Cleaning output folder
@magam/runtime build: CJS Build start
@magam/runtime build: ESM Build start
@magam/cli build: CJS Build start
@magam/cli build: CJS You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/runtime build: CJS You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/runtime build: ESM You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@magam/runtime build: CJS dist/index.js 7.07 KB
@magam/runtime build: CJS ⚡️ Build success in 12ms
@magam/runtime build: ESM dist/index.mjs 5.51 KB
@magam/runtime build: ESM ⚡️ Build success in 12ms
@magam/runtime build: Exited with code 0
@magam/cli build: CJS dist/index.js 1.06 KB
@magam/cli build: CJS dist/bin.js   2.25 MB
@magam/cli build: CJS ⚡️ Build success in 86ms
@magam/cli build: Exited with code 0
magam-app build:  ✓ Compiled successfully in 1928ms
magam-app build:    Linting and checking validity of types ...
magam-app build: 
magam-app build:  ⚠ The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/app/api-reference/config/eslint#migrating-existing-config
magam-app build: 
magam-app build: ./app/api/assets/file/route.integration.spec.ts
magam-app build: 2:37  Warning: 'readFile' is defined but never used.  @typescript-eslint/no-unused-vars
magam-app build: 
magam-app build: ./app/api/assets/file/route.spec.ts
magam-app build: 57:58  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 
magam-app build: ./app/api/assets/upload/route.spec.ts
magam-app build: 2:48  Warning: 'afterEach' is defined but never used.  @typescript-eslint/no-unused-vars
magam-app build: 123:10  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 
magam-app build: ./app/page.tsx
magam-app build: 75:16  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 174:11  Warning: 'updateNode' is assigned a value but never used.  @typescript-eslint/no-unused-vars
magam-app build: 478:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 479:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 712:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 724:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 755:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 826:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 828:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 858:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 
magam-app build: ./components/BubbleOverlay.tsx
magam-app build: 6:19  Warning: 'BUBBLE_THRESHOLD' is defined but never used.  @typescript-eslint/no-unused-vars
magam-app build: 
magam-app build: ./components/edges/FloatingEdge.tsx
magam-app build: 2:31  Warning: 'getBezierPath' is defined but never used.  @typescript-eslint/no-unused-vars
magam-app build: 39:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 45:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 
magam-app build: ./components/nodes/BaseNode.tsx
magam-app build: 52:5  Warning: 'selected' is defined but never used. Allowed unused args must match /^_/u.  @typescript-eslint/no-unused-vars
magam-app build: 
magam-app build: ./components/nodes/MarkdownNode.tsx
magam-app build: 36:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 37:49  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 38:49  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 57:18  Warning: 'node' is defined but never used. Allowed unused args must match /^_/u.  @typescript-eslint/no-unused-vars
magam-app build: 57:57  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 73:17  Warning: 'node' is defined but never used. Allowed unused args must match /^_/u.  @typescript-eslint/no-unused-vars
magam-app build: 73:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
magam-app build: 
magam-app build: info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
magam-app build:    Collecting page data ...
magam-app build:    Generating static pages (0/6) ...
magam-app build:    Generating static pages (1/6) 
magam-app build:    Generating static pages (2/6) 
magam-app build:    Generating static pages (4/6) 
magam-app build:  ✓ Generating static pages (6/6)
magam-app build:    Finalizing page optimization ...
magam-app build:    Collecting build traces ...
magam-app build: 
magam-app build: Route (app)                                 Size  First Load JS
magam-app build: ┌ ○ /                                     795 kB         897 kB
magam-app build: ├ ○ /_not-found                            995 B         103 kB
magam-app build: ├ ƒ /api/assets/file                       156 B         102 kB
magam-app build: ├ ƒ /api/assets/upload                     156 B         102 kB
magam-app build: ├ ƒ /api/chat/groups                       156 B         102 kB
magam-app build: ├ ƒ /api/chat/groups/[id]                  156 B         102 kB
magam-app build: ├ ƒ /api/chat/providers                    156 B         102 kB
magam-app build: ├ ƒ /api/chat/send                         156 B         102 kB
magam-app build: ├ ƒ /api/chat/sessions                     156 B         102 kB
magam-app build: ├ ƒ /api/chat/sessions/[id]                156 B         102 kB
magam-app build: ├ ƒ /api/chat/sessions/[id]/messages       156 B         102 kB
magam-app build: ├ ƒ /api/chat/stop                         156 B         102 kB
magam-app build: ├ ƒ /api/file-tree                         156 B         102 kB
magam-app build: ├ ƒ /api/files                             156 B         102 kB
magam-app build: └ ƒ /api/render                            156 B         102 kB
magam-app build: + First Load JS shared by all             102 kB
magam-app build:   ├ chunks/426-f9267704bf922c1e.js       45.8 kB
magam-app build:   ├ chunks/d924c068-920fa8d3859fcfcd.js  54.2 kB
magam-app build:   └ other shared chunks (total)          1.93 kB
magam-app build: 
magam-app build: 
magam-app build: ƒ Middleware                               34 kB
magam-app build: 
magam-app build: ○  (Static)   prerendered as static content
magam-app build: ƒ  (Dynamic)  server-rendered on demand
magam-app build: 
magam-app build: Exited with code 0 succeeds end-to-end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file response handling to ensure more reliable asset delivery.

* **Chores**
  * Updated development dependencies for better tooling support.
  * Refined build configuration for optimized bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->